### PR TITLE
Download and Plugins fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,17 +43,22 @@ RUN cpanm CPAN::Meta \
 WORKDIR /opt
 RUN curl -LOOO https://github.com/samtools/{samtools/releases/download/1.3.1/samtools-1.3.1,bcftools/releases/download/1.3.1/bcftools-1.3.1}.tar.bz2
 RUN cat *tar.bz2 | tar -ijxf -
-RUN cd samtools-1.3.1 && make && make prefix=/opt/samtools install && ln -s /opt/samtools-1.3.1/samtools /usr/bin/samtools && cd ..
-RUN cd bcftools-1.3.1 && make && make prefix=/opt/samtools install && ln -s /opt/bcftools-1.3.1/bcftools /usr/bin/bcftools && cd ..
+RUN cd samtools-1.3.1 && make && make install && ln -s /opt/samtools-1.3.1/samtools /usr/bin/samtools && cd ..
+RUN cd bcftools-1.3.1 && make && make install && ln -s /opt/bcftools-1.3.1/bcftools /usr/bin/bcftools && cd ..
+RUN rm *.tar.bz2
 
 RUN wget https://github.com/Ensembl/ensembl-tools/archive/release/89.zip
 RUN mkdir variant_effect_predictor_89
-RUN mkdir variant_effect_predictor_89/cache
 RUN unzip 89.zip -d variant_effect_predictor_89
 RUN rm 89.zip
 WORKDIR /opt/variant_effect_predictor_89/ensembl-tools-release-89/scripts/variant_effect_predictor/
-RUN perl INSTALL.pl --AUTO ap --PLUGINS LoF --CACHEDIR /opt/variant_effect_predictor_89/cache
-WORKDIR /opt/variant_effect_predictor_89/cache/Plugins
+RUN perl INSTALL.pl --AUTO ap --PLUGINS LoF --CACHEDIR /opt/variant_effect_predictor_89/tmp_plugins-cache
+
+# During installation of VEP, we don't install the full cache, only the plugins.
+# When preparing the VEP cache in a separate step (docker_vep_cache.sh) the 
+# Plugins folder is moved to the local VEP cache directorty.
+
+WORKDIR /opt/variant_effect_predictor_89/tmp_plugins-cache/Plugins
 RUN wget https://raw.githubusercontent.com/konradjk/loftee/v0.3-beta/splice_module.pl
 
 WORKDIR /opt

--- a/docker_vep_cache.sh
+++ b/docker_vep_cache.sh
@@ -16,15 +16,15 @@ else
     cd $VEP_CACHE
 
     # Download the Ensembl release and reference genome
-    wget ftp://ftp.ensembl.org/pub/release-89/variation/VEP/homo_sapiens_vep_89_GRCh37.tar.gz
-    wget ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz
+    wget -N ftp://ftp.ensembl.org/pub/release-89/variation/VEP/homo_sapiens_vep_89_GRCh37.tar.gz
+    wget -N ftp://ftp.ensembl.org/pub/release-75/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz
 
     # Untar and unzip the Ensembl release and reference genome
     tar -xzf homo_sapiens_vep_89_GRCh37.tar.gz
     gzip -d Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz
 
     # Download the ExAC VCF
-    wget ftp://ftp.broadinstitute.org:/pub/ExAC_release/release0.3.1/subsets/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz
+    wget -N ftp://ftp.broadinstitute.org:/pub/ExAC_release/release0.3.1/subsets/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz
 
     # In a Docker container:
     # - Modify the ExAC VCF
@@ -58,5 +58,12 @@ else
         --species homo_sapiens \
         --version 89_GRCh37 \
         --dir /vep_cache/
+
+    # In a Docker container, move the Plugins directory to $VEP_CACHE/Plugins
+    docker run --rm -it --name vcf2maf \
+      -v $VEP_CACHE:/vep_cache/ \
+      -w /opt/variant_effect_predictor_89/tmp_plugins-cache \
+      thehyve/vcf2maf \
+      /bin/bash -c 'mv Plugins/ /vep_cache/'
   fi
 fi


### PR DESCRIPTION
Implement fixes:
- When downloading always overwrite file
- Move VEP Plugins folder from Docker container to local VEP Cache folder during VEP Cache preparation.